### PR TITLE
Update wslpluginapi to 2.1.3 and add examples for distro registered and unregistered hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 * Build the plugin dll via Visual Studio or msbuild
-* Open a visual studio develloper command prompt as administrator and sign the plugin via: 
+* Open a visual studio developer command prompt as administrator and sign the plugin via:
 `cd path\to\sample-wsl-plugin && powershell .\sign-plugin.ps1 -PluginPath .\x64\Debug\sample-wsl-plugin.dll -Trust`
 
 * Register the plugin with WSL via:

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.WSL.PluginApi" version="2.0.10" targetFramework="native" />
+  <package id="Microsoft.WSL.PluginApi" version="2.1.3" targetFramework="native" />
 </packages>

--- a/wsl-plugin-sample.vcxproj
+++ b/wsl-plugin-sample.vcxproj
@@ -40,7 +40,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>$(MSBuildProjectDirectory)\packages\Microsoft.WSL.PluginApi.2.0.10\build\native\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(MSBuildProjectDirectory)\packages\Microsoft.WSL.PluginApi.2.1.3\build\native\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>


### PR DESCRIPTION
This change updates the plugin api to 2.1.3 and adds samples on how to use the OnDistributionRegistered and OnDistributionUnregistered hooks 